### PR TITLE
Switch to using ims.bentley.com

### DIFF
--- a/core/src/BaseApp.ts
+++ b/core/src/BaseApp.ts
@@ -130,6 +130,7 @@ export class HubArgs implements HubArgsProps {
     this.projectId = props.projectId;
     this.iModelId = props.iModelId;
     this.clientConfig = props.clientConfig;
+    this.clientConfig.issuerUrl = "https://ims.bentley.com";
     if (props.env !== undefined)
       this.env = props.env;
     this.validate();


### PR DESCRIPTION
Resolved the unauthorized error due to insufficient scope and adopted the changes suggested by [blog](https://medium.com/itwinjs/one-scope-to-call-them-all-aedc9840076b).