### PR TITLE
Version should conform to semver.org

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@itwin/pcf",
-  "version": "0.4.0-beta-1",
+  "version": "0.4.0-beta.1",
   "description": "Define your digital twin as code with iTwin PCF (Parametric Connector Framework).",
   "main": "lib/pcf.js",
   "typings": "lib/pcf",


### PR DESCRIPTION
```
<pre-release> ::= <dot-separated pre-release identifiers>

<dot-separated pre-release identifiers> ::= <pre-release identifier>
                                          | <pre-release identifier> "." <dot-separated pre-release identifiers>
```

Oops. Not hyphens.

While we're here, should we discuss versioning?

> Pre-release versions have a lower precedence than the associated normal version.

Should I just drop the pre-release identifiers and do `0.4.0`?

> Major version zero (0.y.z) is for initial development. Anything MAY change at any time. The public API SHOULD NOT be considered stable.