### PR TITLE
Add support for unique aspects without requiring `ECInstanceId`

### DIFF
--- a/core/src/DMO.ts
+++ b/core/src/DMO.ts
@@ -119,6 +119,16 @@ export interface ElementAspectDMO extends DMO {
    * References the BIS class of this element aspect. See {@link ElementDMO#ecElement}.
    */
   readonly ecElementAspect: ECDomainClassFullName | ECDynamicEntityClassProps;
+
+  /**
+   * The attribute of IR instances of this DMO that points to the IR instance each will attach to.
+   *
+   * If omitted, the connector author (you) must specify supply the
+   * [`element`](https://www.itwinjs.org/reference/core-common/entities/elementaspectprops)
+   * property which has type [`RelatedElementProps`](https://www.itwinjs.org/reference/core-common/entities/relatedelementprops)
+   * in {@link DMO#modifyProps}.
+   */
+  elementAttr?: string;
 }
 
 /**

--- a/core/src/test/ExpectedTestResults.ts
+++ b/core/src/test/ExpectedTestResults.ts
@@ -69,11 +69,15 @@ const TestResults: {[sourceFile: string]: QueryToCount} = {
     "select * from TestSchema:ExtPhysicalType where UserLabel='new_mock_user_label'": 3, // attribute update (from v1)
     "select * from TestSchema:ExtPhysicalElement": 3,                 // -2+1 (from v1)
     "select * from TestSchema:ExtGroupInformationElement": 1,         // -1 (from v1)
+    "select * from bis:SubCategory as subcategories inner join bis:Category as categories on subcategories.Parent.id = categories.ECInstanceId where subcategories.Description like '%moved%' and categories.CodeValue = 'ExtSpatialCategory-1'": 1,
     // Element Aspect
     "select * from TestSchema:ExtElementAspectA": 1,
     "select * from TestSchema:ExtElementAspectB": 1,
     "select * from TestSchema:ExtElementAspectA where Name='a-name'": 1,
-    "select * from BisCore:ExternalSourceAspect where identifier='ExtElementAspectA-1'": 1, // provenance of ExtElementAspect
+    "select * from BisCore:ExternalSourceAspect where identifier='ExtElementAspectA-1' and Element.id in (0x20000000010, 0x20) ": 1, // provenance of ExtElementAspect
+    "select * from bis:ChannelRootAspect as aspects inner join TestSchema:ExtPhysicalElement as elements on aspects.Element.id = elements.ECInstanceId where elements.CodeValue in ('ExtPhysicalElement-1', 'ExtPhysicalElement-5')": 2,
+    "select * from bis:ExternalSourceAspect as metas inner join TestSchema:ExtPhysicalElement as elements on metas.Element.id = elements.ECInstanceId where metas.Identifier = 'ElementAspectC-1' and elements.CodeValue = 'ExtPhysicalElement-1'": 1,
+    "select * from bis:ExternalSourceAspect as metas inner join TestSchema:ExtPhysicalElement as elements on metas.Element.id = elements.ECInstanceId where metas.Identifier = 'ElementAspectC-2' and elements.CodeValue = 'ExtPhysicalElement-5'": 1,
     // Relationship
     "select * from TestSchema:ExtElementGroupsMembers": 0,            // -1 (from v1)
     "select * from TestSchema:ExtElementRefersToElements": 2,         // +1 (from v1)
@@ -81,7 +85,6 @@ const TestResults: {[sourceFile: string]: QueryToCount} = {
     "select * from TestSchema:ExtExistingElementRefersToElements": 1,
     "select * from TestSchema:ExtPhysicalElementAssemblesElements": 1,
     "select categories.ECInstanceId from bis:ElementOwnsChildElements as relationships inner join bis:SpatialCategory as categories on relationships.SourceECInstanceId = categories.ECInstanceId": 2, // +1 default subcategory
-    "select * from bis:SubCategory where Description like '%moved%'": 1,
     // Domain Class
     "select * from BuildingSpatial:Space": 1,
     // Nested models, pro bono projects deleted and sushi project added to backlog
@@ -101,6 +104,12 @@ const TestResults: {[sourceFile: string]: QueryToCount} = {
     "select * from TestSchema:ExtElementAspectA": 1,
     "select * from TestSchema:ExtElementAspectB": 1,
     "select * from TestSchema:ExtElementAspectA where Name='a-new-name'": 1, // attribute update
+    "select * from BisCore:ExternalSourceAspect where Identifier='ExtElementAspectA-1'": 1, // provenance update
+    "select * from BisCore:ExternalSourceAspect where Identifier='ExtElementAspectA-1' and element.id in (0x20000000010, 0x20)": 1, // provenance update
+    "select * from bis:ChannelRootAspect": 1,
+    "select * from bis:ChannelRootAspect as aspects inner join TestSchema:ExtPhysicalElement as elements on aspects.Element.id = elements.ECInstanceId where elements.CodeValue = 'ExtPhysicalElement-2'": 1,
+    "select * from bis:ExternalSourceAspect where Identifier = 'ElementAspectC-1'": 1,
+    "select * from bis:ExternalSourceAspect as metas inner join TestSchema:ExtPhysicalElement as elements on metas.Element.id = elements.ECInstanceId where metas.Identifier = 'ElementAspectC-1' and elements.CodeValue = 'ExtPhysicalElement-2'": 1,
     // Nested models, everything deleted; 1 default, 1 for the loader
     "select * from bis:LinkModel": 2,
   },
@@ -108,6 +117,7 @@ const TestResults: {[sourceFile: string]: QueryToCount} = {
     // Element Aspect
     "select * from TestSchema:ExtElementAspectA": 0, // -1 (from v3)
     "select * from TestSchema:ExtElementAspectB": 0, // -1 (from v3)
+    "select * from bis:ChannelRootAspect": 0,        // -1 (from v3)
   },
   "v5.json": { // introduce a new Subject
     "select * from BisCore:Subject": 3,

--- a/core/src/test/JSONConnector/JSONConnector.ts
+++ b/core/src/test/JSONConnector/JSONConnector.ts
@@ -111,7 +111,7 @@ export class JSONConnector extends pcf.PConnector {
       loader: new pcf.JSONLoader({
         format: "json",
         entities: [
-          "ExtElementAspectA", "ExtElementAspectB",
+          "ExtElementAspectA", "ExtElementAspectB", "ElementAspectC",
           "ExtGroupInformationElement",
           "ExtPhysicalElement",
           "ExtPhysicalType",
@@ -188,6 +188,13 @@ export class JSONConnector extends pcf.PConnector {
       model: phyModel,
       dmo: elements.ExtPhysicalElement,
       category: sptCategory
+    });
+
+    new pcf.ElementAspectNode(this, {
+      key: "ElementAspectC",
+      subject: subject1,
+      element: extPhysicalElement,
+      dmo: aspects.ElementAspectC,
     });
 
     const extGroupInformationElement = new pcf.ElementNode(this, {

--- a/core/src/test/JSONConnector/dmos/ElementAspects.ts
+++ b/core/src/test/JSONConnector/dmos/ElementAspects.ts
@@ -1,4 +1,4 @@
-import { BriefcaseDb, ElementUniqueAspect, StandaloneDb } from "@itwin/core-backend";
+import { BriefcaseDb, ChannelRootAspect, ElementUniqueAspect, StandaloneDb } from "@itwin/core-backend";
 import { PrimitiveType, primitiveTypeToString } from "@itwin/ecschema-metadata";
 import { IRInstance, ElementAspectDMO, PConnector } from "../../../pcf";
 
@@ -44,4 +44,11 @@ export const ExtElementAspectB: ElementAspectDMO = {
     else if (pc.db instanceof BriefcaseDb)
       props.element = { id: instance.get("BriefcaseExistingElementId") };
   },
+
+};
+
+export const ElementAspectC: ElementAspectDMO = {
+  irEntity: "ElementAspectC",
+  ecElementAspect: ChannelRootAspect.classFullName,
+  elementAttr: "attachTo",
 };

--- a/core/src/test/assets/v2.json
+++ b/core/src/test/assets/v2.json
@@ -71,6 +71,16 @@
       "StandaloneExistingElementId": "0x20"
     }
   ],
+  "ElementAspectC": [
+    {
+      "id": "1",
+      "attachTo": "1"
+    },
+    {
+      "id": "2",
+      "attachTo": "5"
+    }
+  ],
   "ExtElementRefersToElements": [
     {
       "id": "1",

--- a/core/src/test/assets/v3.json
+++ b/core/src/test/assets/v3.json
@@ -67,6 +67,12 @@
       "StandaloneExistingElementId": "0x20"
     }
   ],
+  "ElementAspectC": [
+    {
+      "id": "1",
+      "attachTo": "2"
+    }
+  ],
   "ExtElementRefersToElements": [
     {
       "id": "1",


### PR DESCRIPTION
This PR brings the API of `ElementAspectNode` closer to the other nodes that create elements with navigation properties.

Keep in mind that `ElementAspectNode` only supports the creation of unique aspects. Tracking the provenance of `bis:ElementMultiAspect` is trickier and not really doable without [changes to the iTwin APIs](https://github.com/iTwin/itwinjs-core/issues/3969). `fir` doesn't make any attempt to do so and just reinserts all aspects attached to an element.

As originally written, the connector author has to intervene in the DMO and specify the `ECInstanceId` of the element to attach the unique aspect to. Now there's an optional `elementAttr` in `ElementAspectDMO`. It's optional to allow compatibility with the old API, which means if you forget to specify both `elementAttr` and the `element` property of your node PCF will throw at runtime. If we can confirm anyone isn't using the old API (very likely) I'd like to drop it.

I've also made changes to the synchronization of aspects to properly track the provenance of an aspect if it attaches itself to a different element. This solution is a hack, but I have [a PR open](https://github.com/iTwin/itwinjs-core/pull/4227) to discuss alternatives.